### PR TITLE
다크모드 혹은 라이트모드 전환으로 인해 리랜더링이 되는 문제 해결

### DIFF
--- a/front/src/util/provider.tsx
+++ b/front/src/util/provider.tsx
@@ -1,5 +1,5 @@
 // Provider.js
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { ThemeProvider } from 'styled-components';
 import useDarkMode from 'use-dark-mode';
@@ -7,10 +7,21 @@ import useDarkMode from 'use-dark-mode';
 import { darkTheme, lightTheme } from './theme';
 
 const Providers = ({ children }: { children: any }) => {
+  const [mounted, setMounted] = React.useState(false);
   const darkMode = useDarkMode(false);
   const theme = darkMode.value ? darkTheme : lightTheme;
 
-  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const body = <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+
+  if (!mounted) {
+    return <div style={{ visibility: 'hidden' }}>{body}</div>;
+  }
+
+  return body;
 };
 
 export default Providers;


### PR DESCRIPTION
- 다크모드와 라이트모드가 마운트 되지 않으면 visibility: hidden으로 아무것도 리턴되지 않는 것처럼 해주고, 완료되면 화면을 그려줌