### PR TITLE
윈도우용 실행명령 추가

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=production node ./dist/index.js",
+    "start": "cross-env NODE_ENV=production node ./dist/index.js",
+    "prewinddev": "yarn run window-api-docs",
+    "windev": "cross-env NODE_ENV=development tsc-watch --onSuccess \"ts-node ./dist/index.js\"",
+    "window-api-docs": "rmdir /s /q dist && mkdir dist\\swagger && swagger-cli bundle swagger\\openapi.yaml --outfile dist\\swagger\\swagger.yaml --type yaml",
     "dev": "NODE_ENV=development tsc-watch --onSuccess \"ts-node ./dist/index.js\"",
     "predev": "yarn run api-docs",
     "api-docs": "mkdir -p dist/swagger && swagger-cli bundle swagger/openapi.yaml --outfile dist/swagger/swagger.yaml --type yaml"


### PR DESCRIPTION
NODE_ENV 에러와 경로 에러 때문에 명령을 새로 만들었습니다.
윈도우로 실행하려면 `npm run windev` 하시면 됩니다.